### PR TITLE
完善贡献者区块：补全贡献者列表并优化显示间距

### DIFF
--- a/index.html
+++ b/index.html
@@ -172,87 +172,34 @@
         <section id="contributors" class="content-section">
             <h2 class="typescale-headline-large section-title">贡献者</h2>
             <div class="card card--filled">
-                <div class="grid-4-col">
-                    <div class="contributor-card">
-                        <a href="https://github.com/CJKmkp" target="_blank" rel="noopener noreferrer">
-                            <img src="https://avatars.githubusercontent.com/u/113243675?v=4" alt="CJK_mkp"
-                                class="contributor-avatar">
-                            <h3 class="typescale-title-medium contributor-name">CJK_mkp</h3>
-                        </a>
-                        <div class="chips-group">
-                            <span class="chip chip--small">Maintenance</span>
-                            <span class="chip chip--small">Documentation</span>
-                            <span class="chip chip--small">Code</span>
-                        </div>
-                    </div>
-                    <div class="contributor-card">
-                        <a href="https://github.com/CreeperAWA" target="_blank" rel="noopener noreferrer">
-                            <img src="https://avatars.githubusercontent.com/u/134939494?v=4" alt="CreeperAWA"
-                                class="contributor-avatar">
-                            <h3 class="typescale-title-medium contributor-name">CreeperAWA</h3>
-                        </a>
-                        <div class="chips-group">
-                            <span class="chip chip--small">Code</span>
-                        </div>
-                    </div>
-                    <div class="contributor-card">
-                        <a href="https://github.com/2-2-3-trimethylpentane" target="_blank" rel="noopener noreferrer">
-                            <img src="https://avatars.githubusercontent.com/u/141403762?v=4" alt="2,2,3-三甲基戊烷"
-                                class="contributor-avatar">
-                            <h3 class="typescale-title-medium contributor-name">2,2,3-三甲基戊烷</h3>
-                        </a>
-                        <div class="chips-group">
-                            <span class="chip chip--small">Blogposts</span>
-                            <span class="chip chip--small">Documentation</span>
-                            <span class="chip chip--small">Design</span>
-                        </div>
-                    </div>
-                    <div class="contributor-card">
-                        <a href="https://github.com/Alan-CRL" target="_blank" rel="noopener noreferrer">
-                            <img src="https://avatars.githubusercontent.com/u/92425617?v=4" alt="Alan-CRL"
-                                class="contributor-avatar">
-                            <h3 class="typescale-title-medium contributor-name">Alan-CRL</h3>
-                        </a>
-                        <div class="chips-group">
-                            <span class="chip chip--small">Code</span>
-                            <span class="chip chip--small">Infrastructure (Hosting, Build-Tools, etc)</span>
-                            <span class="chip chip--small">Documentation</span>
-                            <span class="chip chip--small">Financial</span>
-                        </div>
-                    </div>
-                    <div class="contributor-card">
-                        <a href="https://github.com/MKStoler1024" target="_blank" rel="noopener noreferrer">
-                            <img src="https://avatars.githubusercontent.com/u/158786854?v=4" alt="MKStoler1024"
-                                class="contributor-avatar">
-                            <h3 class="typescale-title-medium contributor-name">MKStoler1024</h3>
-                        </a>
-                        <div class="chips-group">
-                            <span class="chip chip--small">Documentation</span>
-                            <span class="chip chip--small">Code</span>
-                            <span class="chip chip--small">Design</span>
-                        </div>
-                    </div>
-                    <div class="contributor-card">
-                        <a href="https://github.com/awesome-iwb" target="_blank" rel="noopener noreferrer">
-                            <img src="https://avatars.githubusercontent.com/u/184760810?v=4" alt="Awesome Iwb"
-                                class="contributor-avatar">
-                            <h3 class="typescale-title-medium contributor-name">Awesome Iwb</h3>
-                        </a>
-                        <div class="chips-group">
-                            <span class="chip chip--small">Documentation</span>
-                        </div>
-                    </div>
-                    <div class="contributor-card">
-                        <a href="https://github.com/PrefacedCorg" target="_blank" rel="noopener noreferrer">
-                            <img src="https://avatars.githubusercontent.com/u/129855423?v=4" alt="PrefacedCorg"
-                                class="contributor-avatar">
-                            <h3 class="typescale-title-medium contributor-name">PrefacedCorg</h3>
-                        </a>
-                        <div class="chips-group">
-                            <span class="chip chip--small">Code</span>
-                        </div>
-                    </div>
-                </div>
+                <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+                <!-- prettier-ignore-start -->
+                <!-- markdownlint-disable -->
+                <table>
+                    <tbody>
+                        <tr>
+                            <td align="center" valign="top" width="14.28%"><a href="https://github.com/CJKmkp"><img src="https://avatars.githubusercontent.com/u/113243675?v=4?s=100" width="100px;" alt="CJK_mkp" /><br /><sub><b>CJK_mkp</b></sub></a><br /><a href="#maintenance-CJKmkp" title="Maintenance">🚧</a> <a href="#doc-CJKmkp" title="Documentation">📖</a> <a href="#code-CJKmkp" title="Code">💻</a> <a href="#design-CJKmkp" title="Design">🎨</a></td>
+                            <td align="center" valign="top" width="14.28%"><a href="https://github.com/CreeperAWA"><img src="https://avatars.githubusercontent.com/u/134939494?v=4?s=100" width="100px;" alt="CreeperAWA" /><br /><sub><b>CreeperAWA</b></sub></a><br /><a href="#code-CreeperAWA" title="Code">💻</a></td>
+                            <td align="center" valign="top" width="14.28%"><a href="https://github.com/2-2-3-trimethylpentane"><img src="https://avatars.githubusercontent.com/u/141403762?v=4?s=100" width="100px;" alt="2,2,3-三甲基戊烷" /><br /><sub><b>2,2,3-三甲基戊烷</b></sub></a><br /><a href="#blog-2-2-3-trimethylpentane" title="Blogposts">📝</a> <a href="#doc-2-2-3-trimethylpentane" title="Documentation">📖</a> <a href="#design-2-2-3-trimethylpentane" title="Design">🎨</a> <a href="#test-2-2-3-trimethylpentane" title="Tests">⚠️</a> <a href="#tutorial-2-2-3-trimethylpentane" title="Tutorials">✅</a> <a href="#video-2-2-3-trimethylpentane" title="Videos">📹</a></td>
+                            <td align="center" valign="top" width="14.28%"><a href="https://github.com/Alan-CRL"><img src="https://avatars.githubusercontent.com/u/92425617?v=4?s=100" width="100px;" alt="Alan-CRL" /><br /><sub><b>Alan-CRL</b></sub></a><br /><a href="#code-Alan-CRL" title="Code">💻</a> <a href="#infra-Alan-CRL" title="Infrastructure (Hosting, Build-Tools, etc)">🚇</a> <a href="#doc-Alan-CRL" title="Documentation">📖</a> <a href="#financial-Alan-CRL" title="Financial">💵</a></td>
+                            <td align="center" valign="top" width="14.28%"><a href="https://github.com/MKStoler1024"><img src="https://avatars.githubusercontent.com/u/158786854?v=4?s=100" width="100px;" alt="MKStoler1024" /><br /><sub><b>MKStoler1024</b></sub></a><br /><a href="#doc-MKStoler1024" title="Documentation">📖</a> <a href="#code-MKStoler1024" title="Code">💻</a> <a href="#design-MKStoler1024" title="Design">🎨</a></td>
+                            <td align="center" valign="top" width="14.28%"><a href="https://github.com/awesome-iwb"><img src="https://avatars.githubusercontent.com/u/184760810?v=4?s=100" width="100px;" alt="Awesome Iwb" /><br /><sub><b>Awesome Iwb</b></sub></a><br /><a href="#doc-awesome-iwb" title="Documentation">📖</a></td>
+                            <td align="center" valign="top" width="14.28%"><a href="https://github.com/PrefacedCorg"><img src="https://avatars.githubusercontent.com/u/129855423?v=4?s=100" width="100px;" alt="PrefacedCorg" /><br /><sub><b>PrefacedCorg</b></sub></a><br /><a href="#code-PrefacedCorg" title="Code">💻</a> <a href="#design-PrefacedCorg" title="Design">🎨</a></td>
+                        </tr>
+                        <tr>
+                            <td align="center" valign="top" width="14.28%"><a href="http://blog.jursin.top"><img src="https://avatars.githubusercontent.com/u/127487914?v=4?s=100" width="100px;" alt="Jursin" /><br /><sub><b>Jursin</b></sub></a><br /><a href="#design-Jursin" title="Design">🎨</a></td>
+                            <td align="center" valign="top" width="14.28%"><a href="https://github.com/Tayasui-rainnya"><img src="https://avatars.githubusercontent.com/u/156585442?v=4?s=100" width="100px;" alt="tayasui rainnya!" /><br /><sub><b>tayasui rainnya!</b></sub></a><br /><a href="#design-Tayasui-rainnya" title="Design">🎨</a></td>
+                            <td align="center" valign="top" width="14.28%"><a href="https://github.com/doudou0720"><img src="https://avatars.githubusercontent.com/u/98651603?v=4?s=100" width="100px;" alt="doudou0720" /><br /><sub><b>doudou0720</b></sub></a><br /><a href="#code-doudou0720" title="Code">💻</a> <a href="#doc-doudou0720" title="Documentation">📖</a></td>
+                            <td align="center" valign="top" width="14.28%"><a href="https://github.com/PANDAJSR"><img src="https://avatars.githubusercontent.com/u/170189561?v=4?s=100" width="100px;" alt="PANDAJSR" /><br /><sub><b>PANDAJSR</b></sub></a><br /><a href="#code-PANDAJSR" title="Code">💻</a></td>
+                            <td align="center" valign="top" width="14.28%"><a href="http://lyxwx.top"><img src="https://avatars.githubusercontent.com/u/66517348?v=4?s=100" width="100px;" alt="流焰xwx" /><br /><sub><b>流焰xwx</b></sub></a><br /><a href="#code-LiuYan-xwx" title="Code">💻</a></td>
+                            <td align="center" valign="top" width="14.28%"><a href="https://github.com/Super-Yyt"><img src="https://avatars.githubusercontent.com/u/206630707?v=4?s=100" width="100px;" alt="Super-Yyt" /><br /><sub><b>Super-Yyt</b></sub></a><br /><a href="#infra-Super-Yyt" title="Infrastructure (Hosting, Build-Tools, etc)">🚇</a> <a href="#blog-Super-Yyt" title="Blogposts">📝</a></td>
+                        </tr>
+                    </tbody>
+                </table>
+                <!-- markdownlint-restore -->
+                <!-- prettier-ignore-end -->
+                <!-- ALL-CONTRIBUTORS-LIST:END -->
+                <p class="typescale-body-medium card-subtitle" style="text-align: center; margin-top: 0.75rem;">我们永远热爱开源！</p>
             </div>
         </section>
     </main>

--- a/style.css
+++ b/style.css
@@ -553,6 +553,8 @@ img {
 }
 #contributors table td img {
     display: inline-block;
+    border-radius: 50%;
+    object-fit: cover;
 }
 
 

--- a/style.css
+++ b/style.css
@@ -543,6 +543,17 @@ img {
 .contributor-card .chips-group {
     margin-top: 0.5rem;
 }
+#contributors table {
+    width: 100%;
+    border-collapse: separate;
+    border-spacing: 0 0.9rem;
+}
+#contributors table td {
+    padding: 0.25rem 0.35rem;
+}
+#contributors table td img {
+    display: inline-block;
+}
 
 
 /* Footer */


### PR DESCRIPTION
本次 PR 对官网 index.html 的贡献者部分进行了补全与样式优化，提升信息完整性与页面可读性。

# 变更内容

补全“贡献者”区块成员信息（包含第二行成员）。
在贡献者列表末尾新增文案：“我们永远热爱开源！”。
优化贡献者区块样式：
增加表格行间距（border-spacing）
增加单元格内边距
调整头像显示方式，修复头像与名字之间间距过大的问题

# 影响文件

index.html
style.css

# 效果

贡献者信息更完整。
头像与名称间距更自然。
各行之间留白更合理，整体观感更协调。

<img width="1136" height="596" alt="image" src="https://github.com/user-attachments/assets/ce52b841-dc1b-4486-9095-9da43fbed127" />
